### PR TITLE
chore: align beta branch reference to development on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: Node.js CI
 on:
   push:
     branches:
-      - develop
+      - development
       - feature/*
   pull_request:
     branches:
-      - develop
+      - development
       - main
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - develop
+      - development
 
 permissions:
   contents: read

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,7 @@
   "branches": [
     "main",
     {
-      "name": "develop",
+      "name": "development",
       "prerelease": "beta"
     }
   ],


### PR DESCRIPTION
Updates the semantic-release `branches` config and workflow triggers on `main` to reference `development` after the GitHub branch rename (develop → development). Brings main in line with the renamed beta branch.